### PR TITLE
Remove Google Fonts import

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,9 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Inter Font Import - Variable Weight */
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
-
 /* Base Layer - Molecular Minimalist Foundation */
 @layer base {
   html {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -49,8 +49,8 @@ module.exports = {
       
       // Typography Scale - Inter Font Family
       fontFamily: {
-        'sans': ['Inter', 'system-ui', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'sans-serif'],
-        'display': ['Inter', 'system-ui', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'sans-serif'],
+        'sans': ['var(--font-inter)', 'system-ui', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'sans-serif'],
+        'display': ['var(--font-inter)', 'system-ui', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'sans-serif'],
       },
       
       // Scientific Typography Scale


### PR DESCRIPTION
## Summary
- remove Google Fonts @import from globals.css
- use `var(--font-inter)` so Inter loads via next/font

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68633c71f73483298101a7081c2863b8