### PR TITLE
Fix PageWrapper height

### DIFF
--- a/components/layout/PageWrapper.tsx
+++ b/components/layout/PageWrapper.tsx
@@ -18,16 +18,17 @@ export default function PageWrapper({
   }
 
   return (
-    <div className={`
-      min-h-[calc(100vh-400px)]
-      py-12 lg:py-16
-      ${className}
-    `}>
-      <div className={`
-        ${widthClasses[width]}
-        mx-auto
-        px-4 sm:px-6 lg:px-8
-      `}>
+    <div
+      className={`flex min-h-full flex-col py-12 lg:py-16 ${className}`}
+    >
+      <div
+        className={`
+          ${widthClasses[width]}
+          flex-1
+          mx-auto
+          px-4 sm:px-6 lg:px-8
+        `}
+      >
         {children}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- refactor PageWrapper layout to remove hardcoded height calculation

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: package dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68633f2a14908329b51f6ad108b333d4